### PR TITLE
Tire fire v3.3

### DIFF
--- a/Build.sh
+++ b/Build.sh
@@ -23,7 +23,7 @@ rm /usr/bin/TireFire 2> /dev/null
 ln -s "$PWD/TireFire.py" "/usr/bin/TireFire"
 
 apt update
-apt-get install tilix gobuster seclists dconf-cli g++ pip libreoffice smtp-user-enum leafpad -y
+apt-get install tilix dbus-x11 gobuster seclists dconf-cli g++ pip libreoffice smtp-user-enum leafpad -y
 wait
 python3 -m pip install pandasql
 

--- a/TireFire.py
+++ b/TireFire.py
@@ -9,8 +9,10 @@ parser.add_argument("IP", help="IP address of the target", type=str)
 args    = parser.parse_args()
 
 if pwd.getpwuid(os.getuid())[0] != "root":
-    print("TireFire needs to be run as root. Try again.")
+    print("TireFire needs to be run as root.")
     exit()
+if os.environ['USER'] != "root":
+    print("The shell environment user must be root. Try: sudo TireFire x.x.x.x")
 IP      = args.IP
 path    = subprocess.getoutput("readlink /usr/bin/TireFire")
 path    = path[:-12]

--- a/TireFire.py
+++ b/TireFire.py
@@ -13,6 +13,7 @@ if pwd.getpwuid(os.getuid())[0] != "root":
     exit()
 if os.environ['USER'] != "root":
     print("The shell environment user must be root. Try: sudo TireFire x.x.x.x")
+    exit()
 IP      = args.IP
 path    = subprocess.getoutput("readlink /usr/bin/TireFire")
 path    = path[:-12]

--- a/tilix.dconf
+++ b/tilix.dconf
@@ -49,6 +49,7 @@ exit-action='close'
 font='URW Gothic Semi-Bold 12'
 foreground-color='#EFEFEF'
 highlight-colors-set=false
+login-shell=true
 palette=['#000000', '#AA0000', '#00AA00', '#AA5400', '#0000AA', '#AA00AA', '#00AAAA', '#AAAAAA', '#545454', '#FF5454', '#54FF54', '#FFFF54', '#5454FF', '#FF54FF', '#54FFFF', '#FFFFFF']
 terminal-title='${title}'
 text-blink-mode='always'


### PR DESCRIPTION
ISSUE: New session being opened in new windows instead of a new session.
CAUSE: tilix update
FIX: Edited dconf file to reference login shell for new session. Added error handling in TireFire.py to verify the shell environment user.