### PR TITLE
Install fixes

### DIFF
--- a/Build.sh
+++ b/Build.sh
@@ -56,5 +56,5 @@ do
         echo "#"
     fi
 done
-chown 0 -R ./*
+# chown 0 -R ./*
 chmod +x -R *

--- a/Build.sh
+++ b/Build.sh
@@ -23,7 +23,7 @@ ln -s "$PWD/TireFire.py" "/usr/local/bin/TireFire"
 apt update
 apt-get install gobuster seclists dconf-cli g++ pip libreoffice smtp-user-enum leafpad enum4linux smbmap tilix dbus-x11 -y
 wait
-python3 -m pip install pandasql psutil colorama tabulate
+python3 -m pip install -r requirements.txt
 
 if [[ ! -d 'dirsearch' ]]; then git clone https://github.com/maurosoria/dirsearch.git; fi
 chmod -R 755 dirsearch/

--- a/README.md
+++ b/README.md
@@ -159,3 +159,5 @@ Please contact me at CoolHandSquid32@gmail.com for contributions, suggestions, a
 </p>
 
 <p align="center"><a href="https://github.com/coolhandsquid/TireFire#Contents"><img src="https://github.com/CoolHandSquid/TireFire/blob/TireFire_V4/Images/backToTopButton.png" alt="Back to top" height="29"/></a></p>
+
+test

--- a/README.md
+++ b/README.md
@@ -159,5 +159,3 @@ Please contact me at CoolHandSquid32@gmail.com for contributions, suggestions, a
 </p>
 
 <p align="center"><a href="https://github.com/coolhandsquid/TireFire#Contents"><img src="https://github.com/CoolHandSquid/TireFire/blob/TireFire_V4/Images/backToTopButton.png" alt="Back to top" height="29"/></a></p>
-
-test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+netaddr
+click
+psutil
+colorama
+tabulate
+pandas
+pandasql


### PR DESCRIPTION
Added a requirements.txt that is used during the Build.sh install. This will allow a more streamlined and easy to follow installation process for users. Following the standard of having the requirements.txt makes troubleshooting easier. 

The changing of ownership was commented out during my testing it did not interfere with the installation as long as build is ran with sudo. 

The chmod on line 60 should also be looked at for removal and instead only make the necessary files executable.